### PR TITLE
Update 00 Connection Plugin for UCS.ps1 to support Cisco UCS PowerToo…

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for UCS.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for UCS.ps1
@@ -49,10 +49,10 @@ $pLang = DATA {
 Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable pLang -ErrorAction SilentlyContinue
 
 # Load UCS Powertool Module 
-If (!(Get-Module -name CiscoUcsPS -ErrorAction SilentlyContinue)) {
-    Import-Module CiscoUcsPs
+If (!(Get-Module -name Cisco.UCSManager -ErrorAction SilentlyContinue)) {
+    Import-Module Cisco.UCSManager
     
-    If (!(Get-Module -name CiscoUcsPS -ErrorAction SilentlyContinue)) {
+    If (!(Get-Module -name Cisco.UCSManager -ErrorAction SilentlyContinue)) {
 		Write-Error $pLang.loadModFailed
 		Throw
     } Else {


### PR DESCRIPTION
…ls >= 2.0.1

Cisco renamed CiscoUcsPs to Cisco.UCSManager.  All other functionality appears to be retained.

This is required for Cisco UCS PowerTool versions 2.0.1 and higher.